### PR TITLE
Fix a bug in the way the props are passed 🌞

### DIFF
--- a/src/components/materialize.js
+++ b/src/components/materialize.js
@@ -45,7 +45,7 @@ export default React.createClass({
     )
 
     const props = {
-      ...data.props,
+      ...data,
       ...handlerNames.reduce((acc, name) => (
         { ...acc, [name]: buildHandler(name) }
       ), {})

--- a/src/components/scatter.js
+++ b/src/components/scatter.js
@@ -33,7 +33,7 @@ export default React.createClass({
 })
 
 const update = (component) => {
-  const { data, handlers } = splitHandlers(component.props)
+  const { data, handlers } = splitHandlers(component.props.props)
   const entanglement = component.props.adapter || component.context.entanglement
   const handlerNames = Object.keys(handlers)
 


### PR DESCRIPTION
This is a hard to describe, the diff is pretty explicit. It was by chance that we were spreading the right props passed to Materialize, but the handlers were not being sent in Scatter or captured in Materialize. Apparently the demo was working because `onClick` was still being propagated by React.
